### PR TITLE
:bug: 禁用wget代理 修复alist连通性检查的bug

### DIFF
--- a/emby/entrypoint.sh
+++ b/emby/entrypoint.sh
@@ -3,7 +3,7 @@
 ALIST_ADDR=${ALIST_ADDR:-http://alist:5678}
 
 echo "检查alist连通性..."
-while ! wget -q -T 1 -O - "${ALIST_ADDR}/api/public/settings" 2> /dev/null | grep -q 200; do
+while ! wget -Y off -q -T 1 -O - "${ALIST_ADDR}/api/public/settings" 2> /dev/null | grep -q 200; do
     sleep 2
 done
 


### PR DESCRIPTION
启用docker全局代理的情况下 emyb镜像设置no_proxy无效 因为使用busybox内置的wget不读取no_proxy环境变量 但默认启用-Y on选项 导致连通性检查走代理