### PR TITLE
fix: 🐛 emby 无法观看夸克内容

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,7 @@ env:
     QUARK_COOKIE:
     PAN115_COOKIE:
     PIKPAK_USER:
+    DOCKER_ADDRESS:
     ...
 ```
 

--- a/alist/README.md
+++ b/alist/README.md
@@ -57,3 +57,5 @@ docker run -d -p 5678:80 -p 2345:2345 -p 2346:2346 --restart=unless-stopped --na
 `AUTO_CLEAR_INTERVAL`: 自动清理间隔，单位分钟，范围0-60分钟，默认10分钟
 
 `AUTO_CLEAR_THRESHOLD`: 阿里云盘自动清理文件存在时间阈值，单位分钟，范围0-60分钟，默认10分钟
+
+`DOCKER_ADDRESS`: alist 地址，这里需要填写 emby 客户端能正常访问到的地址，如果不使用 emby 观看夸克内容可以不修改，格式：`http://192.168.1.1:5678`

--- a/alist/start.sh
+++ b/alist/start.sh
@@ -8,9 +8,14 @@ if [ ! -d "/data" ]; then
     mkdir /data
 fi
 
-# 设置端口
-local_ip=$(ip a | grep inet | grep -v '127.0.0.1|inet6' | awk '{print $2}' | cut -d/ -f1)
-echo "http://$local_ip:5678" > /data/docker_address.txt
+# 设置 AList 容器地址
+if [ -n "${DOCKER_ADDRESS:-}" ]; then
+    echo "设置 AList 容器地址..."
+    echo "${DOCKER_ADDRESS}" > /data/docker_address.txt
+else
+    local_ip=$(ip a | grep inet | grep -v '127.0.0.1|inet6' | awk '{print $2}' | cut -d/ -f1)
+    echo "http://$local_ip:5678" > /data/docker_address.txt
+fi
 
 # 生成配置，阿里云token
 if [ ${#ALIYUN_TOKEN} -ne 32 ]; then

--- a/env
+++ b/env
@@ -21,6 +21,8 @@ PIKPAK_USER=
 TVBOX_SECURITY=
 # webdav用户名为dav，设置密码。默认用户密码：guest/guest_Api789
 WEBDAV_PASSWORD=
+# alist 地址，这里需要填写 emby 客户端能正常访问到的地址，如果不使用 emby 观看夸克内容可以不修改，格式：`http://192.168.1.1:5678`
+DOCKER_ADDRESS=
 
 # emby 地址，容器内部使用地址，一般不用改
 EMBY_ADDR=http://emby:6908

--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -33,6 +33,7 @@ releases:
           QUARK_COOKIE:
           PAN115_COOKIE:
           PIKPAK_USER:
+          DOCKER_ADDRESS:
         volumes:
         - name: data
           mountPath: /data


### PR DESCRIPTION
添加了一个 `docker_address.txt` 环境变量，以修复emby无法正常播放夸克问题
![image](https://github.com/user-attachments/assets/9fb2fb05-db14-49c4-bb30-a025aae90aad)

![image](https://github.com/user-attachments/assets/64b2fcd2-4e30-4f59-83d0-4f910476e26d)
https://t.me/xiaoyaliu00/383405